### PR TITLE
Reboot-Bitlocker, Reset-Winsock, Set-NetProfilePrivate

### DIFF
--- a/AutomateTools/AutomateTools.psm1
+++ b/AutomateTools/AutomateTools.psm1
@@ -118,3 +118,5 @@ Function Set-EnvironmentPath{
 . $PSScriptRoot\Get-WBStats.ps1
 . $PSScriptRoot\Get-NoahVersion.ps1
 . $PSScriptRoot\Get-FirewallStatus.ps1
+. $PSScriptRoot\Reboot-Bitlocker.ps1
+. $PSScriptRoot\Remove-TempFiles.ps1

--- a/AutomateTools/AutomateTools.psm1
+++ b/AutomateTools/AutomateTools.psm1
@@ -120,3 +120,4 @@ Function Set-EnvironmentPath{
 . $PSScriptRoot\Get-FirewallStatus.ps1
 . $PSScriptRoot\Reboot-Bitlocker.ps1
 . $PSScriptRoot\Remove-TempFiles.ps1
+. $PSScriptRoot\Reset-Winsock.ps1

--- a/AutomateTools/AutomateTools.psm1
+++ b/AutomateTools/AutomateTools.psm1
@@ -121,3 +121,4 @@ Function Set-EnvironmentPath{
 . $PSScriptRoot\Reboot-Bitlocker.ps1
 . $PSScriptRoot\Remove-TempFiles.ps1
 . $PSScriptRoot\Reset-Winsock.ps1
+. $PSScriptRoot\Set-NetProfilePrivate.ps1

--- a/AutomateTools/Get-WBStats.ps1
+++ b/AutomateTools/Get-WBStats.ps1
@@ -44,7 +44,9 @@ Function Get-WBStats {
     )
 
     # Added the Windows Server Backup module if not present
-    If((Get-Command Get-WBSummary*).count -eq 0){
+	#-eq 0 = PSv3+
+	#-eq $null = PSv2
+    If(((Get-Command Get-WBSummary*).count -eq 0) -Or ((Get-Command Get-WBSUmmary*).count -eq $Null)){
         Add-PSSnapIn Windows.ServerBackup
     }
 

--- a/AutomateTools/Get-WBStats.ps1
+++ b/AutomateTools/Get-WBStats.ps1
@@ -46,7 +46,7 @@ Function Get-WBStats {
     # Added the Windows Server Backup module if not present
 	#-eq 0 = PSv3+
 	#-eq $null = PSv2
-    If(((Get-Command Get-WBSummary*).count -eq 0) -Or ((Get-Command Get-WBSUmmary*).count -eq $Null)){
+    If(((Get-Command Get-WBSummary*).count -eq 0) -Or ((Get-Command Get-WBSUmmary*) -eq $Null)){
         Add-PSSnapIn Windows.ServerBackup
     }
 

--- a/AutomateTools/Reboot-Bitlocker.ps1
+++ b/AutomateTools/Reboot-Bitlocker.ps1
@@ -1,0 +1,21 @@
+﻿<#
+.SYNOPSIS
+This command initiates a remote reboot which includes a single-reboot suspension of Bitlocker.
+*Warning* The reboot is forced.
+.EXAMPLE
+Reboot-Bitlocker
+.LINK
+https://github.com/WesScott000/AutomateTools
+#>
+
+Function Reboot-Bitlocker {
+    [regex]$rx = "[O][n]"
+    $BitlockerStatus = (manage-bde -status "C:")[11]
+    if ($rx.Match($BitlockerStatus).Success -eq $True){
+        Suspend-Bitlocker -MountPoint "C:" -RebootCount 1
+        Restart-Computer -Force
+    }
+    Else {
+        Restart-Computer -Force
+    }
+}

--- a/AutomateTools/Reset-Winsock.ps1
+++ b/AutomateTools/Reset-Winsock.ps1
@@ -1,0 +1,13 @@
+﻿<#
+.SYNOPSIS
+This command resets network interfaces using the winsock reset functionality. This command also reboots the computer. 
+.EXAMPLE
+Reset-Network
+.LINK
+https://github.com/WesScott000/AutomateTools
+#>
+
+Function Reset-Winsock {
+    netsh winsock reset
+    Reboot-Bitlocker
+}

--- a/AutomateTools/Set-NetProfilePrivate.ps1
+++ b/AutomateTools/Set-NetProfilePrivate.ps1
@@ -1,0 +1,20 @@
+﻿<#
+.SYNOPSIS
+This command detects the network profile of the currently connected NIC and sets the profile to Private IF it is Public. It does not change domains.
+.EXAMPLE
+Set-NetProfile
+.LINK
+https://github.com/WesScott000/AutomateTools
+#>
+
+Function Set-NetProfilePrivate{
+    #Gets currently connected network profiles
+    $net = Get-NetConnectionProfile -IPv4Connectivity "Internet" -NetworkCategory "Public" -ErrorAction SilentlyContinue
+    if ($net -eq $Null){
+        Write-Host "No public profiles are connected. Unable to switch."
+    }Else{
+        $net.NetworkCategory = "Private"
+        Set-NetConnectionProfile -InputObject $net
+        Write-Host "Set profile to Private."
+    }
+}


### PR DESCRIPTION
Reboot-Bitlocker - Checks system to determine bitlocker status, if active sets to suspended for one reboot, then reboots. If inactive, reboots.

Reset-Winsock - Performs a 'hard-reset' of the tcp/ip stack **and reboots** the machine (reboots using Reboot-Bitlocker)

Set-NetProfilePrivate - Checks to see if any network interfaces with a valid IPV4 address have a NetworkCategory (profile) of 'Public', if so, sets to 'Private'. Else, exit.